### PR TITLE
fix: cross-origin fetch noise, bytes.Reader race, and form decoding fallback

### DIFF
--- a/api.go
+++ b/api.go
@@ -122,18 +122,23 @@ func (ctx *EventContext) MustUnmarshalForm(v interface{}) {
 
 func (ctx *EventContext) UnmarshalForm(v interface{}) (err error) {
 	mf := ctx.R.MultipartForm
-	if ctx.R.MultipartForm == nil {
+	var values map[string][]string
+	if mf != nil {
+		values = mf.Value
+	} else if ctx.R.Form != nil {
+		values = ctx.R.Form
+	} else {
 		return
 	}
 
 	dec := form.NewDecoder()
-	err = dec.Decode(v, mf.Value)
+	err = dec.Decode(v, values)
 	if err != nil {
 		// panic(err)
 		return
 	}
 
-	if len(mf.File) > 0 {
+	if mf != nil && len(mf.File) > 0 {
 		for k, vs := range mf.File {
 			_ = reflectutils.Set(v, k, vs)
 		}

--- a/builder.go
+++ b/builder.go
@@ -55,11 +55,11 @@ func (b *Builder) PacksHandler(contentType string, packs ...ComponentsPack) http
 		buf.WriteString("\n\n")
 	}
 
-	body := bytes.NewReader(buf.Bytes())
+	bodyBytes := buf.Bytes()
 
 	return gziphandler.GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", contentType)
-		http.ServeContent(w, r, "", startTime, body)
+		http.ServeContent(w, r, "", startTime, bytes.NewReader(bodyBytes))
 	}))
 }
 

--- a/corejs/src/fetchInterceptor.ts
+++ b/corejs/src/fetchInterceptor.ts
@@ -12,6 +12,39 @@ const requestMap = new Map<string, { resource: RequestInfo | URL; config?: Reque
 
 const originalFetch: typeof window.fetch = window.fetch
 
+function isCrossOrigin(resource: RequestInfo | URL): boolean {
+  let urlStr: string
+  if (typeof resource === 'string') {
+    urlStr = resource
+  } else if (resource instanceof URL) {
+    urlStr = resource.toString()
+  } else if (typeof Request !== 'undefined' && resource instanceof Request) {
+    urlStr = resource.url
+  } else {
+    return false
+  }
+  try {
+    const url = new URL(urlStr, window.location.href)
+    return url.origin !== window.location.origin
+  } catch {
+    return false
+  }
+}
+
+function notifyResponse(
+  requestId: string,
+  response: Response,
+  customInterceptor: FetchInterceptor
+) {
+  const requestInfo = requestMap.get(requestId)
+  if (customInterceptor.onResponse && requestInfo) {
+    const resource =
+      requestInfo.resource instanceof URL ? requestInfo.resource.toString() : requestInfo.resource
+    customInterceptor.onResponse(requestId, response, resource, requestInfo.config)
+  }
+  requestMap.delete(requestId)
+}
+
 export function initFetchInterceptor(customInterceptor: FetchInterceptor) {
   // do not rewrite fetch in test env
   if (typeof window.__vitest_environment__ !== 'undefined') return
@@ -21,6 +54,12 @@ export function initFetchInterceptor(customInterceptor: FetchInterceptor) {
     ...args: [RequestInfo | URL, init?: RequestInit]
   ): Promise<Response> {
     const [resource, config] = args
+
+    // Skip cross-origin requests (e.g. Google Analytics): we have no insight
+    // into them and forcing a JSON parse on their bodies just produces noise.
+    if (isCrossOrigin(resource)) {
+      return originalFetch(...args)
+    }
 
     // Generate a unique ID for the request
     const requestId = generateUniqueId()
@@ -39,31 +78,13 @@ export function initFetchInterceptor(customInterceptor: FetchInterceptor) {
       // Clone the response to preserve the original response for further use
       const clonedResponse = response.clone()
 
-      // Start processing the response body without waiting
-      const processingPromise = clonedResponse.json()
-
-      processingPromise
-        .then(() => {
-          const requestInfo = requestMap.get(requestId)
-
-          if (customInterceptor.onResponse && requestInfo) {
-            const resource =
-              requestInfo.resource instanceof URL
-                ? requestInfo.resource.toString()
-                : requestInfo.resource
-
-            customInterceptor.onResponse(
-              requestId,
-              response, // Pass the original response
-              resource,
-              requestInfo.config
-            )
-          }
-
-          requestMap.delete(requestId)
-        })
-        .catch((error: unknown) => {
-          errorHandler(error, requestId, customInterceptor)
+      // Start processing the response body without waiting. A non-JSON or
+      // empty body is not an error — only the request lifecycle matters here.
+      clonedResponse
+        .json()
+        .catch(() => undefined)
+        .finally(() => {
+          notifyResponse(requestId, response, customInterceptor)
         })
 
       // Return the original response


### PR DESCRIPTION
## Summary

Three independent bugfixes discovered while running go-plaid in production:

- **fetchInterceptor**: Skip cross-origin requests (e.g. Google Analytics) entirely — we have no insight into them and forcing a JSON parse on their bodies just produces console noise. Also swallow JSON parse errors on same-origin responses gracefully: a non-JSON body is not an error, only the request lifecycle matters.

- **builder.PacksHandler**: Create a new `bytes.Reader` per request to avoid a data race — `http.ServeContent` mutates the reader's seek offset, so concurrent requests sharing the same reader corrupt each other.

- **api.UnmarshalForm**: Fall back to `r.Form` when `MultipartForm` is nil so that URL-encoded POST bodies are decoded correctly.

## Test plan

- [x] Verified cross-origin fetch requests (Google Analytics, third-party scripts) no longer produce JSON parse errors in the console
- [x] Verified concurrent requests to packed JS/CSS assets serve correct content without corruption
- [x] Verified URL-encoded form submissions decode correctly when not using multipart encoding